### PR TITLE
Make the date persistant between tabs

### DIFF
--- a/public/css/pigeonhole.css
+++ b/public/css/pigeonhole.css
@@ -30,3 +30,8 @@ form#incidents th#category {
     width: 1370px;
   }
 }
+
+.home_link, .home_link:hover, .home_link:active {
+  color: #666;
+  text-decoration: none;
+}

--- a/public/css/pigeonhole.css
+++ b/public/css/pigeonhole.css
@@ -31,7 +31,7 @@ form#incidents th#category {
   }
 }
 
-.home_link, .home_link:hover, .home_link:active {
+.home_link, .home_link:link, .home_list:visited, .home_link:hover, .home_link:active {
   color: #666;
   text-decoration: none;
 }

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -22,17 +22,17 @@
 
           %div.navbar-header
             %span.navbar-brand
-              Pigeonhole
+              %a{:href=>"/", :class => "home_link"} Pigeonhole
 
           %div.nav.navbar-nav
             %li
-              %a{:href=>"/"} Categorisation
+              %a{:href=>"/#{@start_date}/#{@end_date}"} Categorisation
             %li
-              %a{:href=>"/alert-frequency"} Alert Frequency
+              %a{:href=>"/alert-frequency/#{@start_date}/#{@end_date}"} Alert Frequency
             %li
-              %a{:href=>"/alert-response"} Alert Response
+              %a{:href=>"/alert-response/#{@start_date}/#{@end_date}"} Alert Response
             %li
-              %a{:href=>"/noise-candidates"} Alert Noise Candidates
+              %a{:href=>"/noise-candidates/#{@start_date}/#{@end_date}"} Alert Noise Candidates
 
           %div.navbar-form.navbar-right
             %form{:action => "", :method => "post", :role => "form", :class => "form-inline"}


### PR DESCRIPTION
Resolves issue #4

I thought it'd be better to keep the URI style, and just change the functionality of the top links to use the start/end date in their urls. This achieves the required functionality of the request without changing the structure of the website, and keeping it query-string free.

I've also enabled the default 'home' functionality on the navbar-brand, which takes the user back to "/", which is the default entry point. Small css change because bootstrap thinks that a link in a navbar-brand should be glaringly ugly.