### PR TITLE
Bugfix: correct post-route and param cleanup logic

### DIFF
--- a/pigeonhole.rb
+++ b/pigeonhole.rb
@@ -80,9 +80,10 @@ get '/noise-candidates/:start_date/:end_date' do
   haml :"noise-candidates"
 end
 
-post '/:date' do
-  uri = params["date"]
-  params.delete("date")
+post '/:start_date/:end_date' do
+  uri = "#{params["start_date"]}/#{params["end_date"]}"
+  params.delete("start_date")
+  params.delete("end_date")
   params.delete("splat")
   params.delete("captures")
   influxdb.save_categories(params)


### PR DESCRIPTION
Date format used to be just one date. Now it's two.

Prior to this fix: clicking 'Save' on Categorisation page resulted in error due to invalid route.

Post fix: route updated to include both start and end date. Logic for `params.delete("date")` extended to include both date parameters.
