### PR TITLE
Handle inserts on an empty database

### DIFF
--- a/lib/influx.rb
+++ b/lib/influx.rb
@@ -27,7 +27,7 @@ module Influx
       entries = []
       begin
         entries = @influxdb.query "select id, time_to_resolve from #{timeseries}"
-        entries = entries[timeseries]
+        entries = entries[timeseries] || []
       rescue InfluxDB::Error => e
         if e.message.match(/^Couldn't find series/)
           existing = []


### PR DESCRIPTION
`entries` on line 29 is assumed to return something, and therefore have a timeseries key to pass down.
However, on empty databases, there are no results, so `entries` on line 30 is `nil`, which breaks when `.select` is called later.

Setting `entries` as an empty array solves this issue, as the select doesn't fail as it does on `nil`

Before change: an empty database cannot be populated with the `./bin/import_from_pd` import script
After change: an empty database can be populated via the import script