### PR TITLE
Introduce a shared pagerduty config for account_name, used to generate api/interface urls

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -9,7 +9,7 @@
 [pagerduty]
   # Auth token can be given with or without the preceding 'Token token='
   auth_token = "2731ca1f7ee10ed57311"
-  api_url    = "https://mycompany.pagerduty.com/api/v1"
+  account_name = "mycompany"
   time_zone  = "Sydney"
 
 [pagerduty.schedules]

--- a/pigeonhole.rb
+++ b/pigeonhole.rb
@@ -46,6 +46,7 @@ get '/:start_date/:end_date' do
   ]
   @start_date = params["start_date"]
   @end_date   = params["end_date"]
+  @pagerduty_url = pagerduty.api_url
   @incidents = influxdb.find_incidents(@start_date, @end_date)
   haml :"index"
 end
@@ -68,6 +69,7 @@ get '/alert-response/:start_date/:end_date' do
   @incidents  = resp[:incidents] || []
   @total      = @incidents.count
   @acked      = @incidents.reject { |x| x['ack_by'].nil? }.count
+  @pagerduty_url = pagerduty.api_url
   @incidents.each do |incident|
     incident['entity'], incident['check'] = incident['incident_key'].split(':', 2)
     incident['ack_by'] = 'N/A' if incident['ack_by'].nil?

--- a/pigeonhole.rb
+++ b/pigeonhole.rb
@@ -46,7 +46,7 @@ get '/:start_date/:end_date' do
   ]
   @start_date = params["start_date"]
   @end_date   = params["end_date"]
-  @pagerduty_url = pagerduty.api_url
+  @pagerduty_url = pagerduty.pagerduty_url
   @incidents = influxdb.find_incidents(@start_date, @end_date)
   haml :"index"
 end
@@ -69,7 +69,7 @@ get '/alert-response/:start_date/:end_date' do
   @incidents  = resp[:incidents] || []
   @total      = @incidents.count
   @acked      = @incidents.reject { |x| x['ack_by'].nil? }.count
-  @pagerduty_url = pagerduty.api_url
+  @pagerduty_url = pagerduty.pagerduty_url
   @incidents.each do |incident|
     incident['entity'], incident['check'] = incident['incident_key'].split(':', 2)
     incident['ack_by'] = 'N/A' if incident['ack_by'].nil?

--- a/views/alert-response.haml
+++ b/views/alert-response.haml
@@ -40,7 +40,7 @@
         %tr
           %td= Time.at(incident['alert_time'])
           %td
-            %a{:href => "https://bltprf.pagerduty.com/incidents/#{incident['id']}"}= incident['id']
+            %a{:href => "#{@pagerduty_url}/incidents/#{incident['id']}"}= incident['id']
           %td= incident['entity']
           %td= incident['check']
           %td= incident['ack_by']

--- a/views/index.haml
+++ b/views/index.haml
@@ -31,7 +31,7 @@
         %tr
           %td= index + 1
           %td
-            %a{:href => "https://bltprf.pagerduty.com/incidents/#{id}"}= id
+            %a{:href => "#{@pagerduty_url}/incidents/#{id}"}= id
           %td= incident['description']
           %td= Time.at(incident['time'])
           %td


### PR DESCRIPTION
Removes hardcoding raised in issue #16
Helper function in lib/pagerduty.rb allows for controllers and views to access the same value.
Reduced down to an account name for ease of configuration, and more control over the base url (which shouldn't ever have a non pagerduty.com domain name, if I'm not mistaken)