### PR TITLE
Set the entries, not existing, var to empty if series doesn't exist

### DIFF
--- a/lib/influx.rb
+++ b/lib/influx.rb
@@ -33,7 +33,7 @@ module Influx
         entries = entries.empty? ? [] : entries[timeseries]
       rescue InfluxDB::Error => e
         if e.message.match(/^Couldn't find series/)
-          existing = []
+          entries = []
         else
           raise
         end


### PR DESCRIPTION
The variable was renamed, so the rescue logic should be renamed as well. 

Failing case: brand new influxdb 0.8.8 with no pigeonhole series enters this codebranch, `entries` doesn't  get initialized, and the code gets upset later when trying to do a select on a nil. 

After: new instances don't explode when importing new data. 