### PR TITLE
Index page refactor

### DIFF
--- a/lib/influx.rb
+++ b/lib/influx.rb
@@ -264,7 +264,7 @@ module Influx
     end
 
     def generate_stats
-      shifts = TOML.load_file('config.toml')['shifts']
+      shifts = TOML.load_file('config.toml')['shifts'] || {}
       time_zone = shifts['time_zone']
       shifts.delete('time_zone')
 

--- a/pigeonhole.rb
+++ b/pigeonhole.rb
@@ -29,8 +29,7 @@ get '/' do
 
   @types = ["ack", "resolve"]
   @stats = ["mean","stddev","95_percentile"]
-
-  @daily_stats, @breakdown_by_time = influxdb.generate_daily_stats
+  @stat_summary = influxdb.generate_stats
   require 'pp'
   pp @daily_stats
   pp @breakdown_by_time

--- a/views/_stats_table.haml
+++ b/views/_stats_table.haml
@@ -1,12 +1,12 @@
 %div{:class => "stats_table"}
-  %div{:class => "title"}
-    = locals[:title]
-  %div{:class => "incidents"}
-    = locals[:stats]["count"] || 0
+  %div{:class => "title", :title => ("From #{locals[:stats][:start]} to #{locals[:stats][:end]}" if locals[:stats][:end])}
+    = locals[:stats][:title]
+    %div{:class => "incidents"}
+    = locals[:stats][:data]["count"] || 0
     incidents
   %div{:class => "s_ack"}
     Acknowledged in 60s:
-    = "#{locals[:stats]["ack_percent_in_60s"]}%"
+    = "#{locals[:stats][:data]["ack_percent_in_60s"]}%"
   %div{:class => "data_table"}
     %table
       - ["",@stats].flatten.each do |s|
@@ -21,4 +21,4 @@
               = @mapper[t]
             - @stats.each do |s|
               %td{:class => "#{s} value"}
-                = locals[:stats]["#{t}_#{s}"].to_i
+                = locals[:stats][:data]["#{t}_#{s}"].to_i

--- a/views/index.haml
+++ b/views/index.haml
@@ -1,13 +1,13 @@
 %div{:class => "today"}
 
   %h2 Total data (last 24 hours)
-  = haml :'_stats_table', :locals => { :stats => @daily_stats, :title => @daily_stats["name"] }
+  = haml :'_stats_table', :locals => { :stats => @stat_summary[0] }
 
 %div{:class => "shifts"}
   %h2 Breakdown by shift
  
-  - @breakdown_by_time.each do |k,b|
-    = haml :'_stats_table', :locals => { :stats => b["data"][:aggregated], :title => b["name"]}
+  - @stat_summary[1..-1].each do |b|
+    = haml :'_stats_table', :locals => { :stats => b}
 
 %h3 Outstanding alerts:
 

--- a/views/index.haml
+++ b/views/index.haml
@@ -3,11 +3,13 @@
   %h2 Total data (last 24 hours)
   = haml :'_stats_table', :locals => { :stats => @stat_summary[0] }
 
-%div{:class => "shifts"}
-  %h2 Breakdown by shift
- 
-  - @stat_summary[1..-1].each do |b|
-    = haml :'_stats_table', :locals => { :stats => b}
+
+- if @stat_summary.length > 1
+  %div{:class => "shifts"}
+    %h2 Breakdown by shift
+   
+    - @stat_summary[1..-1].each do |b|
+      = haml :'_stats_table', :locals => { :stats => b}
 
 %h3 Outstanding alerts:
 


### PR DESCRIPTION
simplify the creation of statistics by way of refactor

shifts are also an optional configuration, so code will also show stats for today, even if no other shifts are defined. 