### PR TITLE
Fix errors in strings and make duration more obvious

### DIFF
--- a/bin/alert_threshold_recommendations.rb
+++ b/bin/alert_threshold_recommendations.rb
@@ -41,9 +41,10 @@ use_log_level_option
 description 'Calculates suggested alert thresholds for removing X% of alerts over a given time period'
 
 on('-p percent', '--percent-to-remove', 'The percent of alerts to remove')
-on('-t duration', '--time-period', 'The amount of time we should look over')
+on('-t duration', '--time-period', 'The amount of time we should look over (e.g. "24 hours", "20 minutes")')
 on('-m more-than', '--more-than', 'Only return results that have more than Y occurences')
-on('-r recover-within', '--recover-within', 'Only return results that recover within this amount of time')
+on('-r recover-within', '--recover-within',
+   'Only return results that recover within this amount of time (e.g. "24 hours", "20 minutes")')
 on('-s sort-by', '--sort-by', 'The field we should sort the returned data by - frequency, threshold, or incident_key')
 
 go!

--- a/bin/alert_threshold_recommendations.rb
+++ b/bin/alert_threshold_recommendations.rb
@@ -29,11 +29,11 @@ main do
   recommendations.each do |r|
     fixed += r[:fixed]
     total += r[:count]
-    puts "#{r[:incident_key]}: #{r[:fixed]} out of #{r[:count]} alerts would not have been\
-          generated with a threshold of #{r[:formatted_threshold]}"
+    puts "#{r[:incident_key]}: #{r[:fixed]} out of #{r[:count]} alerts would not have been " +
+          "generated with a threshold of #{r[:formatted_threshold]}"
   end
-  puts "Total: #{fixed} out of #{total} alerts would not have been generated over\
-          #{incident_key_total} incident_keys"
+  puts "Total: #{fixed} out of #{total} alerts would not have been generated over " +
+          "#{incident_key_total} incident_keys"
 end
 
 use_log_level_option

--- a/lib/influx.rb
+++ b/lib/influx.rb
@@ -37,7 +37,7 @@ module Influx
       oldest = incidents.map { |x| Time.parse(x[:created_on]).to_i }.min - 1
       newest = incidents.map { |x| Time.parse(x[:created_on]).to_i }.max + 1
       begin
-        entries = @influxdb.query "select id, time_to_resolve from #{timeseries}\
+        entries = @influxdb.query "select id, time_to_resolve from #{timeseries}
                                    where time > #{oldest}s and time < #{newest}s"
         entries = entries.empty? ? [] : entries[timeseries]
       rescue InfluxDB::Error => e
@@ -85,7 +85,7 @@ module Influx
       if query_input && query_input[:query_select]
         query_select = query_input[:query_select]
       end
-      influx_query = "#{query_select} from #{timeseries} \
+      influx_query = "#{query_select} from #{timeseries}
                       where time > #{start_date}s and time < #{end_date}s "
       influx_query << query_input[:conditions] if query_input && query_input[:conditions]
       incidents = @influxdb.query(influx_query)
@@ -148,7 +148,7 @@ module Influx
 
       unless group_by.nil?
         aggregated = find_incidents(start_date, end_date,
-                                    :query_select => 'select mean(time_to_ack) as mean_ack,\
+                                    :query_select => 'select mean(time_to_ack) as mean_ack,
                                                       mean(time_to_resolve) as mean_resolve',
                                     :conditions => "group by time(#{group_by}) #{precondition}"
                                    )
@@ -194,8 +194,8 @@ module Influx
 
     def threshold_recommendations(opts)
       data = find_incidents(opts[:start_date], opts[:end_date],
-                            :query_select => "select count(incident_key),\
-                                              percentile(time_to_resolve, #{opts[:percentage]}),\
+                            :query_select => "select count(incident_key),
+                                              percentile(time_to_resolve, #{opts[:percentage]}),
                                               max(time_to_resolve)",
                             :conditions => 'group by incident_key'
                            )
@@ -301,7 +301,7 @@ module Influx
       stat_matrix.flatten!
 
       aggregate_select_str = 'select count(incident_key), ' + %w(ack resolve).map do |type|
-        "MEAN(time_to_#{type}) as #{type}_mean, STDDEV(time_to_#{type}) as #{type}_stddev,\
+        "MEAN(time_to_#{type}) as #{type}_mean, STDDEV(time_to_#{type}) as #{type}_stddev,
          PERCENTILE(time_to_#{type}, 95) as #{type}_95_percentile"
       end.join(', ')
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,1 +1,1 @@
-VERSION = '0.1.0'
+VERSION = '0.1.1'


### PR DESCRIPTION
This fixes https://github.com/bulletproofnetworks/pigeonhole/issues/36 which was caused by broken query strings.

I also added some output to the help text in `bin/alert_threshold_recommendations.rb`. This has been deployed to our staging environment for your testing, @glasnt.
