### PR TITLE
INF-1135 Fix bug dealing with manually triggered incidents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,22 +1,10 @@
-# Rocketships!
-HashSyntax:
-  EnforcedStyle: hash_rockets
-
-# Enforce spaces within Braces
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: space
-
-# Numbers without underscores, please.
+# Numbers with underscores, please.
 Style/NumericLiterals:
-  Enabled: false
+  Enabled: true
 
-# Allow use of "fail", "raise"
-Style/SignalException:
-  Enabled: false
-
-# Allow "not" as well as "!"
-Style/Not:
-  Enabled: false
+# Allow more complex if statements ( if { if { if {} } })
+Metrics/AbcSize:
+  Max: 30
 
 # Allow slightly longer classes
 Metrics/ClassLength:
@@ -30,3 +18,19 @@ Metrics/LineLength:
 # Allow slightly longer methods
 Metrics/MethodLength:
   Max: 50
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+
+# Rocketships!
+HashSyntax:
+  EnforcedStyle: hash_rockets
+
+# Allow use of "fail", "raise"
+Style/SignalException:
+  Enabled: false
+
+# Allow "not" as well as "!"
+Style/Not:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,9 @@ gem 'parallel'
 group :development do
   gem 'shotgun'
   gem 'tux'
-  gem 'pry'
+  gem 'pry',                :require => false
+  gem 'pry-byebug',         :require => false
+  gem 'pry-doc',            :require => false
+  gem 'pry-rescue',         :require => false
+  gem 'pry-stack_explorer', :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Gemfile
 source 'https://rubygems.org'
 
@@ -22,4 +23,5 @@ group :development do
   gem 'pry-doc',            :require => false
   gem 'pry-rescue',         :require => false
   gem 'pry-stack_explorer', :require => false
+  gem 'rubocop',            '> 0.37'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,16 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bond (0.5.1)
+    byebug (9.0.5)
     chronic (0.10.2)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
     citrus (3.0.2)
     coderay (1.1.0)
+    debug_inspector (0.0.2)
     haml (4.0.6)
       tilt
     httparty (0.13.3)
@@ -21,6 +25,7 @@ GEM
     i18n (0.7.0)
     influxdb (0.1.8)
       json
+    interception (0.5)
     json (1.8.2)
     kgio (2.9.3)
     methadone (1.9.0)
@@ -34,6 +39,18 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-doc (0.9.0)
+      pry (~> 0.9)
+      yard (~> 0.8)
+    pry-rescue (1.4.4)
+      interception (>= 0.5)
+      pry
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -70,6 +87,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    yard (0.9.5)
 
 PLATFORMS
   ruby
@@ -85,8 +103,15 @@ DEPENDENCIES
   methadone
   parallel
   pry
+  pry-byebug
+  pry-doc
+  pry-rescue
+  pry-stack_explorer
   shotgun
   sinatra
   toml-rb
   tux
   unicorn
+
+BUNDLED WITH
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    ast (2.3.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bond (0.5.1)
@@ -35,6 +36,9 @@ GEM
     multi_xml (0.5.5)
     numerizer (0.1.1)
     parallel (1.4.1)
+    parser (2.3.1.2)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -56,6 +60,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rainbow (2.1.0)
     raindrops (0.13.0)
     ripl (0.7.1)
       bond (~> 0.5.1)
@@ -65,6 +70,13 @@ GEM
       rack (>= 1.0)
       rack-test (~> 0.6.2)
       ripl (>= 0.7.0)
+    rubocop (0.42.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     shotgun (0.9.1)
       rack (>= 1.0)
     sinatra (1.4.6)
@@ -83,6 +95,7 @@ GEM
       sinatra (>= 1.2.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (1.1.0)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -107,6 +120,7 @@ DEPENDENCIES
   pry-doc
   pry-rescue
   pry-stack_explorer
+  rubocop (> 0.37)
   shotgun
   sinatra
   toml-rb

--- a/bin/alert_threshold_recommendations.rb
+++ b/bin/alert_threshold_recommendations.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.push(File.expand_path(File.join(__FILE__, '..', '..', 'lib')))
 
@@ -18,9 +19,9 @@ main do
     :start_date  => "#{options[:t]} ago",
     :finish_date => 'now',
     :percentage  => options[:p],
-    :more_than  => options[:m],
+    :more_than => options[:m],
     :recover_within => options[:r],
-    :sort_by     => options[:s]
+    :sort_by => options[:s]
   }
   recommendations = influxdb.threshold_recommendations(opts)
   fixed = 0
@@ -29,11 +30,11 @@ main do
   recommendations.each do |r|
     fixed += r[:fixed]
     total += r[:count]
-    puts "#{r[:incident_key]}: #{r[:fixed]} out of #{r[:count]} alerts would not have been " +
-          "generated with a threshold of #{r[:formatted_threshold]}"
+    puts "#{r[:incident_key]}: #{r[:fixed]} out of #{r[:count]} alerts would not have been " \
+         "generated with a threshold of #{r[:formatted_threshold]}"
   end
-  puts "Total: #{fixed} out of #{total} alerts would not have been generated over " +
-          "#{incident_key_total} incident_keys"
+  puts "Total: #{fixed} out of #{total} alerts would not have been generated over " \
+       "#{incident_key_total} incident_keys"
 end
 
 use_log_level_option

--- a/bin/email_reminder_to_oncall
+++ b/bin/email_reminder_to_oncall
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.push(File.expand_path(File.join(__FILE__, '..', '..', 'lib')))
 
@@ -14,7 +15,7 @@ include Methadone::CLILogging
 main do |oncall_date|
   @config = TOML.load_file('config.toml')['email_reminder']
   raise 'Could not load credentials file at config.toml' if @config.nil? || @config.empty?
-  oncall_date  = oncall_date ? Time.parse(oncall_date) : Time.now
+  oncall_date = oncall_date ? Time.parse(oncall_date) : Time.now
   pagerduty = Pagerduty.new
   oncall_staff = pagerduty.oncall(oncall_date)
   oncall_staff.each do |_schedule, users|
@@ -35,7 +36,7 @@ MESSAGE_END
 
   Net::SMTP.start('localhost') do |smtp|
     puts "Sending email to #{address}"
-    smtp.send_message(message, @config['from'], "#{address}")
+    smtp.send_message(message, @config['from'], address.to_s)
   end
 end
 

--- a/bin/import_from_pd
+++ b/bin/import_from_pd
@@ -11,6 +11,13 @@ include Methadone::Main
 include Methadone::CLILogging
 
 main do |start_date, finish_date|
+  if ENV['DEBUG']
+    require 'pry'
+    require 'pry-doc'
+    require 'pry-rescue'
+    require 'pry-byebug'
+    require 'pry-stack_explorer'
+  end
   influxdb    = Influx::Db.new
   pagerduty   = Pagerduty.new
   start_date  = start_date ? Time.parse(start_date).iso8601 : Time.parse("#{Time.now.strftime('%F')} 00:00:00").iso8601

--- a/bin/import_from_pd
+++ b/bin/import_from_pd
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.push(File.expand_path(File.join(__FILE__, '..', '..', 'lib')))
 

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'rubygems'
 require 'bundler/setup'

--- a/lib/highcharts.rb
+++ b/lib/highcharts.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'json'
 
 module HighCharts

--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'httparty'
 require 'json'
 require 'toml'
@@ -40,7 +41,7 @@ class Pagerduty
   end
 
   def incidents(start_date, finish_date = nil)
-    finish_clause     = finish_date ? "&until=#{finish_date}" : ''
+    finish_clause = finish_date ? "&until=#{finish_date}" : ''
     time_zone = @config['time_zone']
     endpoint  = "#{pagerduty_url}/api/v1/incidents?since=#{start_date}#{finish_clause}&time_zone=#{time_zone}"
     response  = request(endpoint)
@@ -64,13 +65,13 @@ class Pagerduty
 
   def add_ack_resolve(incidents)
     Parallel.each(incidents, :in_threads => 20) do |incident|
-      incident_id      = incident[:id]
-      log              = request("#{pagerduty_url}/api/v1/incidents/#{incident_id}/log_entries")
-                         .sort_by { |x| x['created_at'] }
+      incident_id     = incident[:id]
+      log             = request("#{pagerduty_url}/api/v1/incidents/#{incident_id}/log_entries")
+                        .sort_by { |x| x['created_at'] }
       problem_time    = Time.parse(log.map { |entry| entry['created_at'] }.sort.first)
-      acknowledge_by   = nil
-      time_to_ack      = nil
-      time_to_resolve  = nil
+      acknowledge_by  = nil
+      time_to_ack     = nil
+      time_to_resolve = nil
 
       if log.any? { |x| x['type'] == 'acknowledge' }
         acknowledge      = log.find { |x| x['type'] == 'acknowledge' }

--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -67,8 +67,7 @@ class Pagerduty
       incident_id      = incident[:id]
       log              = request("#{pagerduty_url}/api/v1/incidents/#{incident_id}/log_entries")
                          .sort_by { |x| x['created_at'] }
-      problem          = log.find { |x| x['type'] == 'trigger' }
-      problem_time     = Time.parse(problem['created_at'])
+      problem_time    = Time.parse(log.map { |entry| entry['created_at'] }.sort.first)
       acknowledge_by   = nil
       time_to_ack      = nil
       time_to_resolve  = nil

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 VERSION = '0.1.1'

--- a/pigeonhole.rb
+++ b/pigeonhole.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.push(File.expand_path(File.join(__FILE__, '..', 'lib')))
 
@@ -94,13 +95,13 @@ get '/alert-response/:start_date/:end_date' do
   # Build table data
   @incidents  = resp[:incidents] || []
   @total      = @incidents.count
-  @acked      = @incidents.count { |x| x['time_to_ack'] != 0 }
+  @acked      = @incidents.count { |x| (x['time_to_ack']).nonzero? }
   @pagerduty_url = pagerduty.pagerduty_url
   @incidents.each do |incident|
     incident['entity'], incident['check'] = incident['incident_key'].split(':', 2)
     incident['ack_by'] = 'N/A' if incident['ack_by'].nil?
-    incident['time_to_ack'] = 'N/A' if incident['time_to_ack'] == 0
-    incident['time_to_resolve'] = 'N/A' if incident['time_to_resolve'] == 0
+    incident['time_to_ack'] = 'N/A' if (incident['time_to_ack']).zero?
+    incident['time_to_resolve'] = 'N/A' if (incident['time_to_resolve']).zero?
   end
   haml :"alert-response"
 end
@@ -134,7 +135,7 @@ post '/categorisation/:start_date/:end_date' do
 end
 
 post '/pagerduty' do
-  request.body.rewind  # in case someone already read it
+  request.body.rewind # in case someone already read it
   data = JSON.parse(request.body.read)
   begin
     incidents = pagerduty.incidents_from_webhook(data)


### PR DESCRIPTION
Actual code fix:
Instead of relying on the log message of type == trigger which doesn't exist in manually triggered incidents, simply fetch the first available time stamp which will be when the incident started.

And a whole lot of Rubocop
